### PR TITLE
Optimalizations

### DIFF
--- a/src/Q42.ImageResizert/AssetInvalidException.cs
+++ b/src/Q42.ImageResizert/AssetInvalidException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Q42.ImageResizert
+{
+    public class AssetInvalidException : Exception
+    {
+        public AssetInvalidException() : base("Invalid asset")
+        {
+        }
+    }
+}

--- a/src/Q42.ImageResizert/ImageController.cs
+++ b/src/Q42.ImageResizert/ImageController.cs
@@ -21,6 +21,7 @@ namespace Q42.ImageResizert
             try
             {
                 var image = await imageService.GetImageAsync(id, w, h, cover, quality);
+
                 return File(image, "image/jpeg");
             }
             catch (ArgumentException error)
@@ -30,6 +31,10 @@ namespace Q42.ImageResizert
             catch (AssetNotFoundException error)
             {
                 return BadRequest(error.Message);
+            }
+            catch (Exception error)
+            {
+                throw error;
             }
         }
     }

--- a/src/Q42.ImageResizert/Q42.ImageResizert.csproj
+++ b/src/Q42.ImageResizert/Q42.ImageResizert.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.1</Version>
+    <Version>1.1.1</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/Q42/Q42.ImageResizert</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Q42/Q42.ImageResizert</RepositoryUrl>


### PR DESCRIPTION
- cached items are now directly streamed to the output response
- error will be thrown when an image is 0 bytes
- nuget 1.1.1